### PR TITLE
Configure local remote storage for DVC

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,4 @@
+[core]
+    remote = localstorage
+['remote "localstorage"']
+    url = /tmp/dvc_storage


### PR DESCRIPTION
Purpose: Configure a local directory to store DVC-tracked data, ensuring data is separate from the Git repository for efficiency.